### PR TITLE
perf: 空のタイムライン読み込み時の無駄なDBアクセスを削減するため、RedisタイムラインにダミーIDを挿入する機能を追加しました。

### DIFF
--- a/packages/backend/src/core/FanoutTimelineEndpointService.ts
+++ b/packages/backend/src/core/FanoutTimelineEndpointService.ts
@@ -14,6 +14,7 @@ import type { NotesRepository } from '@/models/_.js';
 import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
 import { FanoutTimelineName, FanoutTimelineService } from '@/core/FanoutTimelineService.js';
 import { UtilityService } from '@/core/UtilityService.js';
+import { IdService } from '@/core/IdService.js';
 import { isUserRelated } from '@/misc/is-user-related.js';
 import { isQuote, isRenote } from '@/misc/is-renote.js';
 import { CacheService } from '@/core/CacheService.js';
@@ -60,6 +61,7 @@ export class FanoutTimelineEndpointService {
 		private fanoutTimelineService: FanoutTimelineService,
 		private utilityService: UtilityService,
 		private channelMutingService: ChannelMutingService,
+		private idService: IdService,
 	) {
 	}
 
@@ -220,7 +222,25 @@ export class FanoutTimelineEndpointService {
 			return [...redisTimeline, ...gotFromDb];
 		}
 
-		return await ps.dbFallback(ps.untilId, ps.sinceId, ps.limit);
+		// RedisおよびDBが空の場合、次回以降の無駄なDBアクセスを防ぐためダミーIDを保存する
+		const gotFromDb = await ps.dbFallback(ps.untilId, ps.sinceId, ps.limit);
+		if (
+			redisResultIds.length === 0 &&
+			ps.sinceId == null && ps.untilId == null &&
+			gotFromDb.length === 0
+		) {
+			const dummyId = this.idService.gen();
+
+			Promise.all(ps.redisTimelines.map((tl, i) => {
+				// 有効なソースかつ結果が空だった場合のみダミーを入れる
+				if (redisResult[i] && redisResult[i].length === 0) {
+					return this.fanoutTimelineService.injectDummy(tl, dummyId);
+				}
+				return Promise.resolve();
+			}));
+		}
+
+		return gotFromDb;
 	}
 
 	private async getAndFilterFromDb(noteIds: string[], noteFilter: NoteFilter, idCompare: (a: string, b: string) => number): Promise<MiNote[]> {

--- a/packages/backend/src/core/FanoutTimelineEndpointService.ts
+++ b/packages/backend/src/core/FanoutTimelineEndpointService.ts
@@ -234,7 +234,7 @@ export class FanoutTimelineEndpointService {
 			Promise.all(ps.redisTimelines.map((tl, i) => {
 				// 有効なソースかつ結果が空だった場合のみダミーを入れる
 				if (redisResult[i] && redisResult[i].length === 0) {
-					return this.fanoutTimelineService.injectDummy(tl, dummyId);
+					return this.fanoutTimelineService.injectDummyIfEmpty(tl, dummyId);
 				}
 				return Promise.resolve();
 			}));

--- a/packages/backend/src/core/FanoutTimelineService.ts
+++ b/packages/backend/src/core/FanoutTimelineService.ts
@@ -109,6 +109,11 @@ export class FanoutTimelineService {
 	}
 
 	@bindThis
+	public injectDummy(tl: FanoutTimelineName, id: string) {
+		return this.redisForTimelines.lpush('list:' + tl, id);
+	}
+
+	@bindThis
 	public purge(name: FanoutTimelineName) {
 		return this.redisForTimelines.del('list:' + name);
 	}

--- a/packages/backend/src/core/FanoutTimelineService.ts
+++ b/packages/backend/src/core/FanoutTimelineService.ts
@@ -109,8 +109,18 @@ export class FanoutTimelineService {
 	}
 
 	@bindThis
-	public injectDummy(tl: FanoutTimelineName, id: string) {
+	injectDummy(tl: FanoutTimelineName, id: string) {
 		return this.redisForTimelines.lpush('list:' + tl, id);
+	}
+
+	@bindThis
+	public injectDummyIfEmpty(tl: FanoutTimelineName, id: string): Promise<boolean> {
+		return this.redisForTimelines.eval(
+			'if redis.call("LLEN", KEYS[1]) == 0 then redis.call("LPUSH", KEYS[1], ARGV[1]) return 1 else return 0 end',
+			1,
+			'list:' + tl,
+			id,
+		).then(res => res === 1);
 	}
 
 	@bindThis

--- a/packages/backend/test/unit/FanoutTimelineEndpointService.ts
+++ b/packages/backend/test/unit/FanoutTimelineEndpointService.ts
@@ -67,6 +67,7 @@ describe('FanoutTimelineEndpointService', () => {
 			.overrideProvider(FanoutTimelineService)
 			.useValue({
 				getMulti: jest.fn(),
+				injectDummy: jest.fn(),
 			})
 			.compile();
 
@@ -119,7 +120,7 @@ describe('FanoutTimelineEndpointService', () => {
 		const dbFallback = jest.fn((_untilId: string | null, _sinceId: string | null, _limit: number) => Promise.resolve([] as MiNote[]));
 
 		const ps = {
-			redisTimelines: ['homeTimeline', 'localTimeline'] as FanoutTimelineName[],
+			redisTimelines: [`homeTimeline:${alice.id}`, 'localTimeline'] as FanoutTimelineName[],
 			useDbFallback: true,
 			limit: 10,
 			allowPartial: false,
@@ -129,9 +130,6 @@ describe('FanoutTimelineEndpointService', () => {
 			untilId: null,
 			sinceId: null,
 		};
-
-		// See comments in original file for logic explanation.
-		// Essentially, we expect the fallback to start from the end of the most recent reliable timeline (HTL).
 
 		await service.getMiNotes(ps);
 
@@ -173,7 +171,7 @@ describe('FanoutTimelineEndpointService', () => {
 		const result = await service.getMiNotes(ps);
 
 		// With the fix, we should get note1 and note2.
-		// Without the fix, we would get only note3 (or empty if limit blocked it).
+
 		expect(result).toHaveLength(2);
 		expect(result[0].id).toBe(note1.id);
 		expect(result[1].id).toBe(note2.id);
@@ -224,7 +222,7 @@ describe('FanoutTimelineEndpointService', () => {
 		const dbFallback = jest.fn((untilId: string | null, sinceId: string | null, limit: number) => Promise.resolve([] as MiNote[]));
 
 		const ps = {
-			redisTimelines: ['homeTimeline', 'localTimeline'] as FanoutTimelineName[],
+			redisTimelines: [`homeTimeline:${alice.id}`, 'localTimeline'] as FanoutTimelineName[],
 			useDbFallback: false,
 			limit: 10,
 			allowPartial: true,
@@ -237,9 +235,72 @@ describe('FanoutTimelineEndpointService', () => {
 
 		const result = await service.getMiNotes(ps);
 
-		// With the previous logic, note3 and note4 would be filtered out because they are older than the "threshold" (end of TL1).
 		// With the fixed logic (skipping filter when !useDbFallback), all notes should be present.
 		expect(result).toHaveLength(4);
 		expect(result.map(n => n.id)).toEqual([note1.id, note2.id, note3.id, note4.id]);
+	});
+
+	// Test for dummy ID optimization
+	test('should inject dummy ID when DB fallback returns empty on initial load', async () => {
+		const redisResult: string[][] = [[], []]; // Empty timelines
+
+		fanoutTimelineService.getMulti.mockResolvedValue(redisResult);
+
+		// Mock dbFallback to return empty array
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const dbFallback = jest.fn((_untilId: string | null, _sinceId: string | null, _limit: number) => Promise.resolve([] as MiNote[]));
+
+		const ps = {
+			redisTimelines: [`homeTimeline:${alice.id}`, 'localTimeline'] as FanoutTimelineName[],
+			useDbFallback: true,
+			limit: 10,
+			allowPartial: true,
+			excludePureRenotes: false,
+			dbFallback,
+			noteFilter: () => true,
+			untilId: null,
+			sinceId: null,
+		};
+
+		const result = await service.getMiNotes(ps);
+
+		expect(result).toEqual([]);
+		// Should have tried to inject dummy ID for both empty timelines
+		expect(fanoutTimelineService.injectDummy).toHaveBeenCalledTimes(2);
+		expect(fanoutTimelineService.injectDummy).toHaveBeenCalledWith(`homeTimeline:${alice.id}`, expect.any(String));
+		expect(fanoutTimelineService.injectDummy).toHaveBeenCalledWith('localTimeline', expect.any(String));
+	});
+
+	// Test for behavior when dummy ID exists
+	test('should return empty result when only dummy ID exists in Redis and DB has no newer data', async () => {
+		const now = Date.now();
+		const dummyId = idService.gen(now);
+		// Redis has only dummy ID
+		const redisResult: string[][] = [[dummyId]];
+
+		fanoutTimelineService.getMulti.mockResolvedValue(redisResult);
+
+		// Mock dbFallback (should be called to check for newer notes than the dummy ID)
+
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const dbFallback = jest.fn((_untilId: string | null, _sinceId: string | null, _limit: number) => Promise.resolve([] as MiNote[]));
+
+		const ps = {
+			redisTimelines: [`homeTimeline:${alice.id}`] as FanoutTimelineName[],
+			useDbFallback: true,
+			limit: 10,
+			allowPartial: false,
+			excludePureRenotes: false,
+			dbFallback,
+			noteFilter: () => true,
+			untilId: null,
+			sinceId: null,
+		};
+
+		const result = await service.getMiNotes(ps);
+
+		expect(result).toEqual([]);
+		// Fallback should be called to check for newer notes (ascending check from dummy ID)
+		expect(dbFallback).toHaveBeenCalled();
 	});
 });

--- a/packages/backend/test/unit/FanoutTimelineEndpointService.ts
+++ b/packages/backend/test/unit/FanoutTimelineEndpointService.ts
@@ -68,6 +68,7 @@ describe('FanoutTimelineEndpointService', () => {
 			.useValue({
 				getMulti: jest.fn(),
 				injectDummy: jest.fn(),
+				injectDummyIfEmpty: jest.fn(),
 			})
 			.compile();
 
@@ -266,9 +267,9 @@ describe('FanoutTimelineEndpointService', () => {
 
 		expect(result).toEqual([]);
 		// Should have tried to inject dummy ID for both empty timelines
-		expect(fanoutTimelineService.injectDummy).toHaveBeenCalledTimes(2);
-		expect(fanoutTimelineService.injectDummy).toHaveBeenCalledWith(`homeTimeline:${alice.id}`, expect.any(String));
-		expect(fanoutTimelineService.injectDummy).toHaveBeenCalledWith('localTimeline', expect.any(String));
+		expect(fanoutTimelineService.injectDummyIfEmpty).toHaveBeenCalledTimes(2);
+		expect(fanoutTimelineService.injectDummyIfEmpty).toHaveBeenCalledWith(`homeTimeline:${alice.id}`, expect.any(String));
+		expect(fanoutTimelineService.injectDummyIfEmpty).toHaveBeenCalledWith('localTimeline', expect.any(String));
 	});
 
 	// Test for behavior when dummy ID exists

--- a/packages/backend/test/unit/FanoutTimelineService.ts
+++ b/packages/backend/test/unit/FanoutTimelineService.ts
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, jest, test, expect, afterEach, beforeAll, afterAll } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as Redis from 'ioredis';
+import { FanoutTimelineService } from '@/core/FanoutTimelineService.js';
+import { IdService } from '@/core/IdService.js';
+import { DI } from '@/di-symbols.js';
+
+describe('FanoutTimelineService', () => {
+	let app: TestingModule;
+	let service: FanoutTimelineService;
+	let redisForTimelines: jest.Mocked<Redis.Redis>;
+	let idService: IdService;
+
+	beforeAll(async () => {
+		app = await Test.createTestingModule({
+			providers: [
+				FanoutTimelineService,
+				{
+					provide: IdService,
+					useValue: {
+						parse: jest.fn(),
+						gen: jest.fn(),
+					},
+				},
+				{
+					provide: DI.redisForTimelines,
+					useValue: {
+						eval: jest.fn(),
+						lpush: jest.fn(),
+						lrange: jest.fn(),
+						del: jest.fn(),
+						pipeline: jest.fn(() => ({
+							lpush: jest.fn(),
+							ltrim: jest.fn(),
+							lrange: jest.fn(),
+							exec: jest.fn(),
+						})),
+					},
+				},
+			],
+		}).compile();
+
+		app.enableShutdownHooks();
+
+		service = app.get<FanoutTimelineService>(FanoutTimelineService);
+		redisForTimelines = app.get(DI.redisForTimelines);
+		idService = app.get<IdService>(IdService);
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	afterEach(async () => {
+		jest.clearAllMocks();
+	});
+
+	test('injectDummyIfEmpty should call Redis EVAL with correct script', async () => {
+		redisForTimelines.eval.mockResolvedValue(1);
+
+		const result = await service.injectDummyIfEmpty('homeTimeline:123', 'dummyId');
+
+		expect(redisForTimelines.eval).toHaveBeenCalledWith(
+			expect.stringContaining('if redis.call("LLEN", KEYS[1]) == 0 then'),
+			1,
+			'list:homeTimeline:123',
+			'dummyId',
+		);
+		expect(result).toBe(true);
+	});
+
+	test('injectDummyIfEmpty should return false if list is not empty', async () => {
+		redisForTimelines.eval.mockResolvedValue(0);
+
+		const result = await service.injectDummyIfEmpty('homeTimeline:123', 'dummyId');
+
+		expect(redisForTimelines.eval).toHaveBeenCalled();
+		expect(result).toBe(false);
+	});
+});


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
